### PR TITLE
Bugfix customFluid1DStencil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v1.1.1, 2024-02-21
+## v1.1.1, 2024-02-26
 
 - Bug fixes
 
@@ -19,6 +19,7 @@
 ### Bug Fixes
 
 - Fixed bug where addTermDiagnosis calls in the wrapper always displayed a warning
+- Fixed bug in customFluid1DStencil where the required variables were not correctly set to "none" when not passed
 
 ## v1.1.0, 2024-02-02
 

--- a/RMK_support/simple_containers.py
+++ b/RMK_support/simple_containers.py
@@ -1666,11 +1666,15 @@ def customFluid1DStencil(
             xStencil
         ), "varContColumnVars must be of same length as xStencil in customFluid1DStencil"
         stencil.update({"columnVarContVars": varContColumnVars})
+    else: 
+        stencil.update({"columnVarContVars":["none" for _ in xStencil]})
     if mbDataColumnVars is not None:
         assert len(mbDataColumnVars) == len(
             xStencil
         ), "mbDataColumnVars must be of same length as xStencil in customFluid1DStencil"
         stencil.update({"columnMBDataVars": mbDataColumnVars})
+    else:
+        stencil.update({"columnMBDataVars":["none" for _ in xStencil]})
 
     return stencil
 

--- a/RMK_support/simple_containers.py
+++ b/RMK_support/simple_containers.py
@@ -1666,15 +1666,15 @@ def customFluid1DStencil(
             xStencil
         ), "varContColumnVars must be of same length as xStencil in customFluid1DStencil"
         stencil.update({"columnVarContVars": varContColumnVars})
-    else: 
-        stencil.update({"columnVarContVars":["none" for _ in xStencil]})
+    else:
+        stencil.update({"columnVarContVars": ["none" for _ in xStencil]})
     if mbDataColumnVars is not None:
         assert len(mbDataColumnVars) == len(
             xStencil
         ), "mbDataColumnVars must be of same length as xStencil in customFluid1DStencil"
         stencil.update({"columnMBDataVars": mbDataColumnVars})
     else:
-        stencil.update({"columnMBDataVars":["none" for _ in xStencil]})
+        stencil.update({"columnMBDataVars": ["none" for _ in xStencil]})
 
     return stencil
 


### PR DESCRIPTION
The customFluid1DStencil function now correctly adds "none" to the required column variables when none are passed.