### PR TITLE
Harmonic offset in kinetic diagonal stencil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # CHANGELOG
-## v2.0.0-beta.2, 2025-06-23
+## v2.0.0-beta.2, 2025-06-24
 
 - See beta.1 notes
 - Support for v1.3 BDE integrator rewrite 
 - Support for v1.3 distribution divergence stencil
+- Support for v1.3 diagonal kinetic stencil upgrade
 
 ### Breaking Changes
 
@@ -18,6 +19,7 @@
 - See beta.1 notes
 - Updated BDE integrator options 
 - New DistDivStencil class that includes the Jacobian in d/dx operator for distributions
+- New harmonicOffset argument for diagonal stencil to allow for direct harmonic coupling
 
 ### Bug Fixes
 

--- a/RMK_support/model_construction.py
+++ b/RMK_support/model_construction.py
@@ -954,6 +954,7 @@ class DiagonalStencil(Stencil):
         evolvedXCells: Optional[List[int]] = None,
         evolvedHarmonics: Optional[List[int]] = None,
         evolvedVCells: Optional[List[int]] = None,
+        harmonicOffset: int = 0,
     ):
         """Diagonal stencil allowing for evolving only specific grid points. If row and column variables are on different grids this stencil will perform linear interpolation/extrapolation.
 
@@ -961,14 +962,17 @@ class DiagonalStencil(Stencil):
             evolvedXCells (Optional[List[int]], optional): List of evolved spatial cells (Fortran 1-indexing). Defaults to None, evolving all cells.
             evolvedHarmonics (Optional[List[int]], optional): List of evolved harmonics (Fortran 1-indexing). Defaults to None, evolving all harmonics.
             evolvedVCells (Optional[List[int]], optional): List of evolved velocity cells. Defaults to None, evolving all cells.
+            harmonicOffset (int, optional): Harmonic offset in case of kinetic stencil, for example if the offset is -1, this is equivalent to having f_{l-1} on the RHS instead of f_l. Defaults to 0.
         """
         properties: Dict[str, object] = {
             "stencilType": "diagonalStencil",
+            "harmonicOffset": 0,
             "evolvedXCells": evolvedXCells if evolvedXCells is not None else [],
             "evolvedHarmonics": (
                 evolvedHarmonics if evolvedHarmonics is not None else []
             ),
             "evolvedVCells": evolvedVCells if evolvedVCells is not None else [],
+            "harmonicOffset": harmonicOffset,
         }
         super().__init__("$0", properties)
 

--- a/RMK_support/tests/test_common_models.py
+++ b/RMK_support/tests/test_common_models.py
@@ -1283,6 +1283,7 @@ def test_stationaryIonEIColl(grid: Grid, norms: dict):
             },
             "stencilData": {
                 "stencilType": "diagonalStencil",
+                "harmonicOffset": 0,
                 "evolvedXCells": [],
                 "evolvedHarmonics": evolvedHarmonics,
                 "evolvedVCells": [],
@@ -1677,6 +1678,7 @@ def test_flowingIonEIColl(grid: Grid, norms: dict):
             },
             "stencilData": {
                 "stencilType": "diagonalStencil",
+                "harmonicOffset": 0,
                 "evolvedXCells": [],
                 "evolvedHarmonics": [2],
                 "evolvedVCells": [],
@@ -1713,6 +1715,7 @@ def test_flowingIonEIColl(grid: Grid, norms: dict):
             },
             "stencilData": {
                 "stencilType": "diagonalStencil",
+                "harmonicOffset": 0,
                 "evolvedXCells": [],
                 "evolvedHarmonics": [2],
                 "evolvedVCells": [],
@@ -1749,6 +1752,7 @@ def test_flowingIonEIColl(grid: Grid, norms: dict):
             },
             "stencilData": {
                 "stencilType": "diagonalStencil",
+                "harmonicOffset": 0,
                 "evolvedXCells": [],
                 "evolvedHarmonics": [2],
                 "evolvedVCells": [],
@@ -1785,6 +1789,7 @@ def test_flowingIonEIColl(grid: Grid, norms: dict):
             },
             "stencilData": {
                 "stencilType": "diagonalStencil",
+                "harmonicOffset": 0,
                 "evolvedXCells": [],
                 "evolvedHarmonics": [2],
                 "evolvedVCells": [],
@@ -1821,6 +1826,7 @@ def test_flowingIonEIColl(grid: Grid, norms: dict):
             },
             "stencilData": {
                 "stencilType": "diagonalStencil",
+                "harmonicOffset": 0,
                 "evolvedXCells": [],
                 "evolvedHarmonics": [2],
                 "evolvedVCells": [],
@@ -1857,6 +1863,7 @@ def test_flowingIonEIColl(grid: Grid, norms: dict):
             },
             "stencilData": {
                 "stencilType": "diagonalStencil",
+                "harmonicOffset": 0,
                 "evolvedXCells": [],
                 "evolvedHarmonics": [2],
                 "evolvedVCells": [],
@@ -1893,6 +1900,7 @@ def test_flowingIonEIColl(grid: Grid, norms: dict):
             },
             "stencilData": {
                 "stencilType": "diagonalStencil",
+                "harmonicOffset": 0,
                 "evolvedXCells": [],
                 "evolvedHarmonics": [2],
                 "evolvedVCells": [],
@@ -1929,6 +1937,7 @@ def test_flowingIonEIColl(grid: Grid, norms: dict):
             },
             "stencilData": {
                 "stencilType": "diagonalStencil",
+                "harmonicOffset": 0,
                 "evolvedXCells": [],
                 "evolvedHarmonics": [2],
                 "evolvedVCells": [],
@@ -1965,6 +1974,7 @@ def test_flowingIonEIColl(grid: Grid, norms: dict):
             },
             "stencilData": {
                 "stencilType": "diagonalStencil",
+                "harmonicOffset": 0,
                 "evolvedXCells": [],
                 "evolvedHarmonics": [2],
                 "evolvedVCells": [],
@@ -2692,6 +2702,7 @@ def test_eeCollHigherL(grid: Grid, norms: dict):
             },
             "stencilData": {
                 "stencilType": "diagonalStencil",
+                "harmonicOffset": 0,
                 "evolvedXCells": [],
                 "evolvedHarmonics": [2],
                 "evolvedVCells": [],
@@ -2839,6 +2850,7 @@ def test_eeCollHigherL(grid: Grid, norms: dict):
             },
             "stencilData": {
                 "stencilType": "diagonalStencil",
+                "harmonicOffset": 0,
                 "evolvedXCells": [],
                 "evolvedHarmonics": [2],
                 "evolvedVCells": [],
@@ -3882,6 +3894,7 @@ def test_standard_base_fluid(grid: Grid):
                 },
                 "stencilData": {
                     "stencilType": "diagonalStencil",
+                    "harmonicOffset": 0,
                     "evolvedXCells": [],
                     "evolvedHarmonics": [],
                     "evolvedVCells": [],
@@ -3949,6 +3962,7 @@ def test_standard_base_fluid(grid: Grid):
                 },
                 "stencilData": {
                     "stencilType": "diagonalStencil",
+                    "harmonicOffset": 0,
                     "evolvedXCells": [],
                     "evolvedHarmonics": [],
                     "evolvedVCells": [],
@@ -3985,6 +3999,7 @@ def test_standard_base_fluid(grid: Grid):
                 },
                 "stencilData": {
                     "stencilType": "diagonalStencil",
+                    "harmonicOffset": 0,
                     "evolvedXCells": [],
                     "evolvedHarmonics": [],
                     "evolvedVCells": [],
@@ -4021,6 +4036,7 @@ def test_standard_base_fluid(grid: Grid):
                 },
                 "stencilData": {
                     "stencilType": "diagonalStencil",
+                    "harmonicOffset": 0,
                     "evolvedXCells": [],
                     "evolvedHarmonics": [],
                     "evolvedVCells": [],
@@ -4119,6 +4135,7 @@ def test_standard_base_fluid(grid: Grid):
                 },
                 "stencilData": {
                     "stencilType": "diagonalStencil",
+                    "harmonicOffset": 0,
                     "evolvedXCells": [],
                     "evolvedHarmonics": [],
                     "evolvedVCells": [],
@@ -4217,6 +4234,7 @@ def test_standard_base_fluid(grid: Grid):
                 },
                 "stencilData": {
                     "stencilType": "diagonalStencil",
+                    "harmonicOffset": 0,
                     "evolvedXCells": [],
                     "evolvedHarmonics": [],
                     "evolvedVCells": [],
@@ -4253,6 +4271,7 @@ def test_standard_base_fluid(grid: Grid):
                 },
                 "stencilData": {
                     "stencilType": "diagonalStencil",
+                    "harmonicOffset": 0,
                     "evolvedXCells": [],
                     "evolvedHarmonics": [],
                     "evolvedVCells": [],

--- a/RMK_support/tests/test_model_construction.py
+++ b/RMK_support/tests/test_model_construction.py
@@ -60,6 +60,7 @@ def test_matrix_term_arithmetic(grid):
         },
         "stencilData": {
             "stencilType": "diagonalStencil",
+            "harmonicOffset": 0,
             "evolvedXCells": [],
             "evolvedHarmonics": [],
             "evolvedVCells": [],


### PR DESCRIPTION
Enables use of feature in: https://github.com/ukaea/ReMKiT1D/pull/26

Now the user can pass `harmonicOffset` to the `DiagonalStencil` constructor to allow for harmonic coupling using this stencil. 

For example, if the user wishes to couple harmonics with the harmonic below them, they should pass `harmonicOffset = 1`. 