### PR TITLE
Patch .readthedocs OS version to ubuntu-lts-latest

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-lts-latest
   tools:
     python: "3.9"
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,4 @@ holoviews
 matplotlib
 pypandoc_binary
 scipy
+pylatex


### PR DESCRIPTION
Fixes #73.

- Replaces deprecated ReadTheDocs OS build version `ubuntu-20.04` with the latest LTS version supported by the library. The use of the "latest" OS is in line with other scripts in ReMKiT1D-Python including the GitHub CI.
- Added `pylatex` to `docs/requirements.txt` as this dependency is needed by ReadTheDocs.